### PR TITLE
Update README GoDoc links.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![GoDoc](http://godoc.org/github.com/tleyden/cb-heartbeat?status.png)](http://godoc.org/github.com/tleyden/cb-heartbeat) [![Build Status](https://drone.io/github.com/couchbase/cb-heartbeat/status.png)](https://drone.io/github.com/couchbase/cb-heartbeat/latest)
+[![GoDoc](http://godoc.org/github.com/couchbase/cb-heartbeat?status.png)](http://godoc.org/github.com/couchbase/cb-heartbeat) [![Build Status](https://drone.io/github.com/couchbase/cb-heartbeat/status.png)](https://drone.io/github.com/couchbase/cb-heartbeat/latest)
 
 This provides a generic heartbeat mechanism for anything that needs to run in
 multiple nodes (machines, or even just in multiple processes on one machine) and


### PR DESCRIPTION
Fixes the link to GoDoc. The current links to GoDoc point to the old repo, so the link is broken.
